### PR TITLE
Handle unique index on MySQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,25 @@ Just pass the `per_batch` option with the records per batch. Example...
 User.mass_insert(values, per_batch: 1000)
 ```
 
+## Handle unique index on MySQL
+Some times we want to ignore errors when adding duplicated records. MySQL has
+the ability to do that with `ON DUPLICATE KEY UPDATE`.
+
+By using the option `handle_duplication` we will ignore the new values by doing:
+
+```sql
+INSERT INTO table (a,b,c) VALUES (1,2,3)
+  ON DUPLICATE KEY UPDATE a=a,b=b,c=c;
+```
+
+[Read more about the MySQL feature.](http://dev.mysql.com/doc/refman/5.7/en/insert-on-duplicate.html).
+
+Usage:
+
+```ruby
+User.mass_insert(values, handle_duplication: true)
+```
+
 
 ## Contributing
 1. Fork it

--- a/lib/mass_insert/adapters/abstract_adapter.rb
+++ b/lib/mass_insert/adapters/abstract_adapter.rb
@@ -10,7 +10,7 @@ module MassInsert
       end
 
       def to_sql
-        "#{insert_sql} #{values_sql}"
+        "#{insert_sql} #{values_sql};"
       end
 
       private
@@ -38,7 +38,7 @@ module MassInsert
       end
 
       def values_sql
-        "(#{array_of_attributes_sql.join('),(')});"
+        "(#{array_of_attributes_sql.join('),(')})"
       end
 
       def array_of_attributes_sql

--- a/lib/mass_insert/adapters/mysql2_adapter.rb
+++ b/lib/mass_insert/adapters/mysql2_adapter.rb
@@ -1,5 +1,15 @@
 module MassInsert
   module Adapters
-    class Mysql2Adapter < AbstractAdapter; end
+    class Mysql2Adapter < AbstractAdapter
+      def to_sql
+        "#{insert_sql} #{values_sql} #{on_duplicate_key_update};"
+      end
+
+      def on_duplicate_key_update
+        if @options[:handle_duplication]
+          "ON DUPLICATE KEY UPDATE #{quoted_columns.map { |quoted_column| "#{quoted_column}=#{quoted_column}" }.join(',')}"
+        end
+      end
+    end
   end
 end

--- a/test/adapters/mysql2/example_test.rb
+++ b/test/adapters/mysql2/example_test.rb
@@ -1,3 +1,31 @@
 require 'test_helper'
 
 shared_examples
+
+describe 'Database Adapters' do
+  let(:attributes) do
+    {
+      name: 'Ruby',
+    }
+  end
+
+  after :each do
+    Kind.delete_all
+  end
+
+  describe 'with duplicated record' do
+    def setup
+      Kind.mass_insert([attributes])
+    end
+
+    it 'does not raises error if is duplicated and has the duplication handler on' do
+      Kind.mass_insert([attributes], handle_duplication: true)
+    end
+
+    it 'raises error if is duplicated and does not have the duplication handler on' do
+      assert_raises ActiveRecord::RecordNotUnique do
+        Kind.mass_insert([attributes])
+      end
+    end
+  end
+end

--- a/test/models/kind.rb
+++ b/test/models/kind.rb
@@ -1,0 +1,2 @@
+class Kind < ActiveRecord::Base
+end

--- a/test/schema.rb
+++ b/test/schema.rb
@@ -8,4 +8,10 @@ ActiveRecord::Schema.define do
 
     t.timestamps null: false
   end
+
+  create_table :kinds, force: true do |t|
+    t.string  :name
+
+    t.index ["name"], name: "index_kinds_on_name", unique: true, using: :btree
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -17,6 +17,21 @@ FileUtils.mkdir_p('log')
 
 ActiveRecord::Base.logger = Logger.new('log/test.log')
 ActiveRecord::Base.logger.level = Logger::DEBUG
+
+# Try to create database if not exists
+if adapter != 'sqlite3'
+  config_without_database = YAML.load_file(File.dirname(__FILE__) + '/database.yml')[adapter]
+  database = config_without_database.delete('database')
+  ActiveRecord::Base.configurations['test'] = config_without_database
+  ActiveRecord::Base.establish_connection(:test)
+  conn = ActiveRecord::Base.connection
+
+  begin
+    conn.execute("CREATE DATABASE #{database}")
+  rescue
+  end
+end
+
 ActiveRecord::Base.configurations['test'] = YAML.load_file(File.dirname(__FILE__) + '/database.yml')[adapter]
 ActiveRecord::Base.establish_connection(:test)
 


### PR DESCRIPTION
Some times we want to ignore errors when adding duplicated records. MySQL has the ability to do that with `ON DUPLICATE KEY UPDATE`.

By using the option `handle_duplication` we will ignore the new values by doing:

```sql
INSERT INTO table (a,b,c) VALUES (1,2,3)
  ON DUPLICATE KEY UPDATE a=a,b=b,c=c;
```

Read more about the MySQL feature:
http://dev.mysql.com/doc/refman/5.7/en/insert-on-duplicate.html

Usage:

```ruby
User.mass_insert(values, handle_duplication: true)
```