### PR TITLE
Dups column_names

### DIFF
--- a/lib/mass_insert/adapters/abstract_adapter.rb
+++ b/lib/mass_insert/adapters/abstract_adapter.rb
@@ -17,7 +17,7 @@ module MassInsert
 
       def columns
         @columns ||= begin
-          columns = column_names
+          columns = column_names.dup
           columns.delete(primary_key) unless options[:primary_key]
           columns.map(&:to_sym)
         end


### PR DESCRIPTION
Prevents this frozen error on Rails 6.1

```
FrozenError (can't modify frozen Array: ["id", "...", "created_at", "updated_at"])
```